### PR TITLE
Fixed: TrustedLogin Connector plugin "Need Help" links to https://docs.trustedlogin.com/vendor/intro, which doesn't exist

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -20,7 +20,8 @@ export const TopBar = ({ status }) => {
         <div className="relative flex items-center space-x-2">
           <StatusMenu toggleStatus={toggleStatus} isStatusOpen={isStatusOpen} />
           <a
-            href="https://docs.trustedlogin.com/Vendor/intro"
+            target={"_blank"}
+            href="https://docs.trustedlogin.com/Connector/intro"
             className="inline-flex items-center px-3.5 h-10 border border-gray-300 text-sm leading-4 font-medium rounded-lg text-gray-900 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 ring-offset-2 focus:ring-sky-500">
             <svg
               className="-ml-0.5 h-4 w-4 sm:mr-2"

--- a/src/components/Onboarding.js
+++ b/src/components/Onboarding.js
@@ -331,7 +331,9 @@ export const OnboardingLayout = ({
                     <div className="inline-flex items-center justify-center">
                       <a
                         className="text-sm text-blue-tl"
-                        href="https://docs.trustedlogin.com/Vendor/intro">
+                        target={"_blank"}
+                        href="https://docs.trustedlogin.com/Connector/intro"
+                      >
                         {__(
                           "Need Help? View our Documentation",
                           "trustedlogin-connector"

--- a/src/components/StatusMenu.js
+++ b/src/components/StatusMenu.js
@@ -271,7 +271,9 @@ const StatusMenu = ({ toggleStatus, isStatusOpen }) => {
               <div className="mb-8 inline-flex items-center">
                 <a
                   className="text-sm text-blue-tl"
-                  href="https://docs.trustedlogin.com/Vendor/intro">
+                  target={"_blank"}
+                  href="https://docs.trustedlogin.com/Connector/intro"
+                >
                   {__(
                     "Need help? View our Documentation",
                     "trustedlogin-connector"


### PR DESCRIPTION
The purpose of this PR is to ensure that links are updated to point to the correct pages in the docs. Furthermore I add `target="_blank"` so that they open in a new page.

💾 [Build file](http://trustedlogin.sfo3.digitaloceanspaces.com/github-trustedlogin-connector-builds/trustedlogin-connector-1.1.1-5198738.zip) (5198738).