### PR TITLE
Fixed: When there are multiple teams you cannot connect to the team selected in the dropdown

### DIFF
--- a/src/components/AccessKeyForm.js
+++ b/src/components/AccessKeyForm.js
@@ -280,7 +280,7 @@ const AccessKeyForm = ({ initialAccountId = null, minimal = false }) => {
                           id="ak_account_id"
                           className="bg-white block w-full pl-3 pr-8 py-2.5 sm:text-sm border border-gray-300 rounded-lg focus:outline-none focus:border-sky-500 focus:ring-1 ring-offset-2 focus:ring-sky-500">
                         {teamsOption.map(({ label, value }) => (
-                            <option key={label} value={label}>
+                            <option key={value} value={value}>
                               {label}
                             </option>
                         ))}


### PR DESCRIPTION
The purpose of this PR is to fix the Access Key Log-In form. When there are more than 1 key currently the label is being passed to connect and not the account ID causing an error. This PR ensures that the account ID is passed.

https://www.loom.com/share/c16209b3e6ae4ded88025c823ddd1736

💾 [Build file](http://trustedlogin.sfo3.digitaloceanspaces.com/github-trustedlogin-connector-builds/trustedlogin-connector-1.1.1-af5b10c.zip) (af5b10c).